### PR TITLE
fixed bug when space in build path with mpi run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ pkg_get_variable(PETSC_CXX_COMPILER PETSc cxxcompiler)
 set(CMAKE_CXX_COMPILER ${PETSC_CXX_COMPILER})
 
 # Set the project details
-project(CHREST VERSION 0.0.6)
+project(CHREST VERSION 0.0.7)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED PETSc)

--- a/tests/testFixtures/MpiTestFixture.cpp
+++ b/tests/testFixtures/MpiTestFixture.cpp
@@ -60,7 +60,7 @@ void MpiTestFixture::RunWithMPI() const {
     std::stringstream mpiCommand;
     mpiCommand << MpiTestFixture::mpiCommand << " ";
     mpiCommand << "-n " << mpiTestParameter.nproc << " ";
-    mpiCommand << ExecutablePath() << " ";
+    mpiCommand << "\"" << ExecutablePath() << "\" ";
     mpiCommand << InTestRunFlag << " ";
     mpiCommand << "--gtest_filter=" << TestName() << " ";
     mpiCommand << mpiTestParameter.arguments << " ";


### PR DESCRIPTION
this PR adds quotes to the mpi command in the tests and closes #13 